### PR TITLE
Added dummy openldap ExternalSecret definitions under aws templates and rhacm (providers)

### DIFF
--- a/clusters/deploy/external-secrets/aws/templates/secret-openldap.yaml
+++ b/clusters/deploy/external-secrets/aws/templates/secret-openldap.yaml
@@ -11,10 +11,10 @@ spec:
   data:
   - secretKey: adminPassword
     remoteRef:
-      key: 91b5a6de-a9be-2b91-a3e8-2b09e3390bcb
+      key: 561166f2-3c06-4c61-9531-422bb0ea3485
   - secretKey: configPassword
     remoteRef:
-      key: 57afa209-35b7-da90-5b92-9621cc27030c
+      key: 223d4d5d-7e70-482d-b923-c80fc9031581
   refreshInterval: 24h0m0s
   secretStoreRef:
     name: cluster

--- a/clusters/deploy/external-secrets/aws/templates/secret-openldap.yaml
+++ b/clusters/deploy/external-secrets/aws/templates/secret-openldap.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  creationTimestamp: null
+  name: {{ .Values.cluster }}-openldap
+  annotations:
+    argocd.argoproj.io/sync-wave: "355"
+    helm.sh/hook-weight: "355"
+  namespace: {{ .Values.cluster }}
+spec:
+  data:
+  - secretKey: adminPassword
+    remoteRef:
+      key: 91b5a6de-a9be-2b91-a3e8-2b09e3390bcb
+  - secretKey: configPassword
+    remoteRef:
+      key: 91b5a6de-a9be-2b91-a3e8-2b09e3390bcb
+  refreshInterval: 24h0m0s
+  secretStoreRef:
+    name: cluster
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.cluster }}-openldap
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        adminPassword: |-
+          {{ "{{ .adminPassword | toString }}" }}
+        configPassword: |-
+          {{ "{{ .configPassword | toString }}" }}

--- a/clusters/deploy/external-secrets/aws/templates/secret-openldap.yaml
+++ b/clusters/deploy/external-secrets/aws/templates/secret-openldap.yaml
@@ -14,7 +14,7 @@ spec:
       key: 91b5a6de-a9be-2b91-a3e8-2b09e3390bcb
   - secretKey: configPassword
     remoteRef:
-      key: 91b5a6de-a9be-2b91-a3e8-2b09e3390bcb
+      key: 57afa209-35b7-da90-5b92-9621cc27030c
   refreshInterval: 24h0m0s
   secretStoreRef:
     name: cluster

--- a/rhacm/providers/aws/external-secrets/aws.yaml
+++ b/rhacm/providers/aws/external-secrets/aws.yaml
@@ -22,6 +22,12 @@ spec:
   - secretKey: openshiftSSHPublicKey
     remoteRef:
       key: 2a4c460c-4443-3d29-ee43-18b21b9c6b3b
+  - secretKey: adminPassword
+    remoteRef:
+      key: 561166f2-3c06-4c61-9531-422bb0ea3485
+  - secretKey: configPassword
+    remoteRef:
+      key: 223d4d5d-7e70-482d-b923-c80fc9031581
   refreshInterval: 24h0m0s
   secretStoreRef:
     name: cluster
@@ -42,3 +48,5 @@ spec:
         pullSecret: "{{ .openshiftPullSecret | toString }}"
         ssh-publickey: "{{ .openshiftSSHPublicKey | toString }}"
         ssh-privatekey: "{{ .openshiftSSHPrivateKey | toString }}"
+        adminPassword: "{{ .adminPassword | toString }}"
+        configPassword: "{{ .configPassword | toString }}"


### PR DESCRIPTION
Those are just dummy key uuids. I don't have access to Secrets Manager at present.